### PR TITLE
Calculate processing time

### DIFF
--- a/src/render.coffee
+++ b/src/render.coffee
@@ -1,3 +1,44 @@
+clc = require 'cli-color'
+ansiStrip = require 'cli-color/strip'
+
+options =
+  verbose: true
+  duration: true
+  maxDuration: 400
+
+last = null
+total = 0
+slower = []
+
+prefix = (data) ->
+  if options.duration
+    "#{duration(data)} #{identifier(data)}"
+  else
+    "#{identifier(data)}"
+
+identifier = (data) ->
+  id = connectionId data
+  result = ''
+  result += "#{clc.magenta.italic(data.subgraph.join(':'))} " if data.subgraph
+  result += clc.blue.italic id
+  return result
+
+duration = (data) ->
+  {time} = data
+  current = new Date(time).getTime()
+  unless last
+    last = current
+  dur = current - last
+  last = current
+  ms = dur.toFixed 0
+  total += dur
+  if ms > options.maxDuration
+    slower.push
+      duration: ms
+      payload: data
+    return clc.red.bold "(#{ms}ms)"
+  else
+    return clc.green "(#{ms}ms)"
 
 
 connectionId = (data) ->
@@ -8,34 +49,23 @@ connectionId = (data) ->
   else
     return "-> #{tgt.port.toUpperCase()} #{tgt.node}"
 
-
 renderText = (msg, options={}) ->
   return null if msg.protocol != 'network'
-
-  clc = require 'cli-color'
-  ansiStrip = require('cli-color/strip');
-
-  identifier = (data) ->
-    id = connectionId data
-    result = ''
-    result += "#{clc.magenta.italic(data.subgraph.join(':'))} " if data.subgraph
-    result += clc.blue.italic id
-    return result
 
   if msg.error
     return "TRACE ERROR: #{msg.error}"
 
   data = msg.payload
   text = switch msg.command
-    when 'connect' then "#{identifier(data)} #{clc.yellow('CONN')}"
-    when 'disconnect' then "#{identifier(data)} #{clc.yellow('DISC')}"
-    when 'begingroup' then "#{identifier(data)} #{clc.cyan('< ' + data.group)}"
-    when 'endgroup' then "#{identifier(data)} #{clc.cyan('> ' + data.group)}"
+    when 'connect' then "#{identifier(data)} #{clc.yellow('CONN')} #{duration(data)}"
+    when 'disconnect' then "#{identifier(data)} #{clc.yellow('DISC')} #{duration(data)}"
+    when 'begingroup' then "#{identifier(data)} #{clc.cyan('< ' + data.group)} #{duration(data)}"
+    when 'endgroup' then "#{identifier(data)} #{clc.cyan('> ' + data.group)} #{duration(data)}"
     when 'data'
       if options.verbose
-        "#{identifier(data)} #{clc.green('DATA')} #{data.data}"
+        "#{identifier(data)} #{clc.green('DATA')} #{data.data} #{duration(data)}"
       else
-        "#{identifier(data)} #{clc.green('DATA')}"
+        "#{identifier(data)} #{clc.green('DATA')} #{duration(data)}"
     else null
 
   if not process?.stdout.isTTY
@@ -48,11 +78,18 @@ exports.main = () ->
   filepath = process.argv[2]
   trace = require './trace'
 
-  options =
-    verbose: true
-
   trace.loadFile filepath, (err, tr) ->
     throw err if err
     for e in tr.events
       text = renderText e, options
       console.log text if text
+    if options.duration
+      console.log "Total duration: #{total}ms\n"
+      console.log "Slower events:"
+      for slow in slower
+        id = identifier slow.payload
+        time = clc.red.bold "(#{slow.duration}ms)"
+        if not process?.stdout.isTTY
+          id = ansiStrip id
+          time = ansiStrip time
+        console.log "#{id} #{time}"


### PR DESCRIPTION
Based on events' timestamp, calculate durations from one event to another and show a summary of slower events:

![2015-12-29-011458_543x118_scrot](https://cloud.githubusercontent.com/assets/49062/12029215/7a9099c2-adcc-11e5-8085-a81a11ca60d3.png)

![2015-12-29-011511_340x275_scrot](https://cloud.githubusercontent.com/assets/49062/12029216/7f323df0-adcc-11e5-92a8-d5e7cf5a16a4.png)


This is a quick implementation I'm using to discover time consuming components. It seems to cover the "naive" one suggested on #19.